### PR TITLE
Improvements to HDR

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "video_utils"
-version = "3.10.0"
+version = "3.12.0"
 description = "Package for transcoding video files to h264/h265 codec"
 readme = "README.md"
 authors = [

--- a/src/video_utils/config/__init__.py
+++ b/src/video_utils/config/__init__.py
@@ -138,6 +138,17 @@ BASEPARSER.add_argument(
     ),
 )
 BASEPARSER.add_argument(
+    '--crop',
+    action='store_true',
+    help=(
+        "Set to enable cropping of black bars from video. "
+        "We try to guess the crop area by looking at a few slices of the "
+        "video to determine how much to crop. If the crop region is too "
+        "small, or none found, then on crop is performed. Otherwise, crop "
+        "video during covert."
+    )
+)
+BASEPARSER.add_argument(
     "--lang",
     type=str,
     default='eng',

--- a/src/video_utils/mediainfo.py
+++ b/src/video_utils/mediainfo.py
@@ -371,9 +371,6 @@ class MediaInfo:
         if 'Video' not in self.__mediainfo:
             self.__log.warning('No video information!')
             return None
-        if len(self.__mediainfo['Video']) > 1:
-            self.__log.error('More than one (1) video stream...Stopping!')
-            return None
 
         encoder = ''
         video_data = self.__mediainfo['Video'][0]
@@ -387,6 +384,7 @@ class MediaInfo:
 
         info = {
             'order': ('-map', '-filter', '-opts'),
+            'nstream': len(self.__mediainfo['Video']),
         }
         for tag in info['order']:
             info[tag] = []
@@ -395,6 +393,18 @@ class MediaInfo:
 
         # Set resolution and rate factor based on video height
         resolution, crf = set_resolution(video_data['Height'])
+
+        if resolution <= 1080 and info['nstream'] > 1:
+            self.__log.error(
+                'More than one (1) video stream in HD or lower...Stopping!',
+            )
+            return None
+
+        if resolution > 1080 and info['nstream'] > 2:
+            self.__log.error(
+                'More than two (2) video stream in UHD...Stopping!',
+            )
+            return None
 
         if resolution <= 1080 and not x265:
             encoder = 'x264'
@@ -479,6 +489,7 @@ class MediaInfo:
         )
 
         if dolby_vision_file:
+            dolby_vision_file = dolby_vision_file.replace("'", r"\'")
             x265_opts.extend(
                 [
                     "dolby-vision-profile=8.1",
@@ -486,6 +497,7 @@ class MediaInfo:
                 ]
             )
         if hdr10plus_file:
+            hdr10plus_file = hdr10plus_file.replace("'", r"\'")
             x265_opts.extend(
                 ["dhdr10-opt=1", f"dhdr10-info={hdr10plus_file}"]
             )

--- a/src/video_utils/utils/hdr_utils.py
+++ b/src/video_utils/utils/hdr_utils.py
@@ -7,9 +7,11 @@ Use the dovi_tool and/or hdr10plus_tool to extract HDR information.
 
 import logging
 import os
-from subprocess import Popen, STDOUT, DEVNULL
+from subprocess import Popen, STDOUT, PIPE, DEVNULL
 
 from .ffmpeg_utils import extract_hevc
+
+BLOCK = 4096
 
 RUST_CARGO = os.path.join(
     os.path.expanduser('~'),
@@ -26,11 +28,11 @@ HDR10PLUS_TOOL = os.path.join(
 )
 
 
-def ingect_hdr(hevc_file, dolby_vision_file, hdr10plus_file):
+def inject_hdr(hevc_file, dolby_vision_file, hdr10plus_file):
     """
     Ingect Dolby Vision/HDR10 data
 
-    Given an HEVC encoded video file ingect Dolby Vision
+    Given an HEVC encoded video file inject Dolby Vision
     and or HDR10+ metadata into the file.
 
     Arguments:
@@ -49,6 +51,116 @@ def ingect_hdr(hevc_file, dolby_vision_file, hdr10plus_file):
     hevc_file = hdr10plus_inject(hevc_file, hdr10plus_file)
 
     return hevc_file
+
+
+def extract_hdr(
+    src_file: str,
+    out_file: str | None = None,
+    crop: bool = False,
+) -> str | None:
+    """
+    Attempt to extract Dolby Vision and HDR10+ data
+
+    This function will pull out an hevc_mp4toannexb formatted video from
+    an mkv file and pipe the data into both the dovi_tool and hdr10plus_tool.
+
+    Arguments:
+        src_file (str) : Path to mkv file to extract/convert stream from
+            to then feed into the HDR tools
+        out_file (str): Output file for reencoded file; used to create HDR
+            metadata names
+
+    Keyword arguments:
+        crop (bool): If set, will use the --crop flag in the dovi_tool.
+
+    Returns:
+        tuple: path the dovi and hdr files, respectively. If no issues, then
+            will be string, else will be None
+
+    """
+
+    log = logging.getLogger(__name__)
+
+    dovi_tool = DOVI_TOOL
+    if not os.path.isfile(DOVI_TOOL):
+        log.error("dovi_tool NOT installed!")
+        dovi_tool = None
+
+    hdr10plus_tool = HDR10PLUS_TOOL
+    if not os.path.isfile(HDR10PLUS_TOOL):
+        log.error("hdr10plus_tool NOT installed!")
+        hdr10plus_tool = None
+
+    if dovi_tool is None and hdr10plus_tool is None:
+        return None, None
+
+    out_file, _ = os.path.splitext(out_file or src_file)
+    dovi_out_file = out_file + '.bin'
+    hdr_out_file = out_file + '.json'
+
+    if dovi_tool:
+        dovi_cmd = [dovi_tool, '--mode', '2']
+        if crop:
+            dovi_cmd.append('--crop')
+        dovi_cmd += [
+            'extract-rpu',
+            '-o', dovi_out_file,
+            '-',
+        ]
+
+    if hdr10plus_tool:
+        hdr_cmd = [
+            hdr10plus_tool,
+            "extract",
+            "-o", hdr_out_file,
+            "-",
+        ]
+
+    extract = extract_hevc(src_file)
+    objs = {}
+    if dovi_tool:
+        log.info(
+            "Extracting Dolby Vision data: %s --> %s",
+            src_file,
+            dovi_out_file,
+        )
+        log.debug('Running command: %s', dovi_cmd)
+        objs['Dolby Vision'] = {
+            'proc': Popen(dovi_cmd, stdin=PIPE, stdout=DEVNULL, stderr=STDOUT),
+            'out_file': dovi_out_file,
+        }
+    if hdr10plus_tool:
+        log.info("Extracting HDR10+ data: %s --> %s", src_file, hdr_out_file)
+        log.debug('Running command: %s', hdr_cmd)
+        objs['HDR10+'] = {
+            'proc': Popen(hdr_cmd, stdin=PIPE, stdout=DEVNULL, stderr=STDOUT),
+            'out_file': hdr_out_file,
+        }
+
+    data = extract.stdout.read(BLOCK)  # Read chunk from extract command
+    while data != b"":  # While not metpy
+        for info in objs.values():  # Iterate over HDR extractors
+            info['proc'].stdin.write(data)  # Write and flush data
+            info['proc'].stdin.flush()
+        data = extract.stdout.read(BLOCK)  # Read another bloack
+
+    extract.stdout.close()
+
+    for key, info in objs.items():
+        info['proc'].stdin.close()
+
+        if info['proc'].wait() != 0:
+            log.warning("Failed to extract %s data!", key)
+            info['out_file'] = None
+
+        if not check_file(info['out_file']):
+            log.warning("Issue with %s metadata file!", key)
+            info['out_file'] = None
+
+    return (
+        objs.get('Dolby Vision', {}).get('out_file', None),
+        objs.get('HDR10+', {}).get('out_file', None),
+    )
 
 
 def dovi_inject(hevc_file, dolby_vision_file):
@@ -85,6 +197,7 @@ def dovi_inject(hevc_file, dolby_vision_file):
         "-o", out_file,
     ]
 
+    log.debug('Running command: %s', cmd)
     proc = Popen(cmd, stdout=DEVNULL, stderr=STDOUT)
     if proc.wait() == 0:
         # command finished successfully!
@@ -102,6 +215,7 @@ def dovi_extract(
     src_file: str,
     out_file: str | None = None,
     ext: str = ".bin",
+    crop: bool = False,
 ) -> str | None:
     """
     Run 'dovi_tool' for Dolby Vision data
@@ -126,10 +240,10 @@ def dovi_extract(
     if not out_file.endswith(ext):
         out_file += ext
 
-    cmd = [
-        DOVI_TOOL,
-        '-c',
-        '-m', '2',
+    cmd = [DOVI_TOOL, '--mode', '2']
+    if crop:
+        cmd.append('--crop')
+    cmd += [
         'extract-rpu',
         '-o', out_file,
         '-',
@@ -137,6 +251,8 @@ def dovi_extract(
 
     log.info("Extracting Dolby Vision data: %s --> %s", src_file, out_file)
     extract = extract_hevc(src_file)
+
+    log.debug('Running command: %s', cmd)
     proc = Popen(cmd, stdin=extract.stdout, stdout=DEVNULL, stderr=STDOUT)
     extract.stdout.close()
 
@@ -185,6 +301,7 @@ def hdr10plus_inject(hevc_file, hdr10plus_file):
         "-o", out_file,
     ]
 
+    log.debug('Running command: %s', cmd)
     proc = Popen(cmd, stdout=DEVNULL, stderr=STDOUT)
     if proc.wait() == 0:
         # command finished successfully!
@@ -202,6 +319,7 @@ def hdr10plus_extract(
     src_file: str,
     out_file: str | None = None,
     ext: str = ".json",
+    **kwargs,
 ) -> str | None:
     """
     Run 'hdr10plus_tool' for Dolby Vision data
@@ -236,6 +354,7 @@ def hdr10plus_extract(
     log.info("Extracting HDR10+ data: %s --> %s", src_file, out_file)
     extract = extract_hevc(src_file)
 
+    log.debug('Running command: %s', cmd)
     proc = Popen(cmd, stdin=extract.stdout, stdout=DEVNULL, stderr=STDOUT)
     extract.stdout.close()
 

--- a/src/video_utils/videoconverter.py
+++ b/src/video_utils/videoconverter.py
@@ -70,6 +70,7 @@ class VideoConverter(ComRemove, MediaInfo, opensubtitles.OpenSubtitles):
         subtitles: bool = False,
         srt: bool = False,
         sub_delete_source: bool = False,
+        crop: bool = False,
         **kwargs,
     ):
         """
@@ -116,6 +117,7 @@ class VideoConverter(ComRemove, MediaInfo, opensubtitles.OpenSubtitles):
         self.srt = srt
         self.cpulimit = cpulimit if isinstance(cpulimit, int) else 75
         self.threads = threads
+        self.crop = crop
 
         self.subtitles = False
         if subtitle_extract.CLI is None:
@@ -402,13 +404,30 @@ class VideoConverter(ComRemove, MediaInfo, opensubtitles.OpenSubtitles):
         self.__log.info("Transcode SUCCESSFUL!")
 
         if self.hevc_file:
-            self.hevc_file = hdr_utils.ingect_hdr(
+            self.hevc_file = hdr_utils.inject_hdr(
                 self.hevc_file,
                 self.dolby_vision_file,
                 self.hdr10plus_file,
             )
 
-            cmd = ["mkvmerge", "-o", outfile, self.hevc_file, self.others_file]
+            # Base command for merge
+            cmd = ["mkvmerge", "-o", outfile, self.hevc_file]
+
+            # If there were 2 video streams in the input file, then we
+            # assume is Dolby Vision FEL data and just copy that second track
+            # into the output.
+            if self.video_info.get('nstream', 1) == 2:
+                cmd += [
+                    '--video-tracks', '1',
+                    '--no-audio',
+                    '--no-subtitles',
+                    '--no-buttons',
+                    '--no-chapters',
+                    '--no-attachments',
+                    self.infile,
+                ]
+            cmd.append(self.others_file)
+
             proc = POPENPOOL.popen_async(cmd)
             proc.wait()
 
@@ -467,13 +486,10 @@ class VideoConverter(ComRemove, MediaInfo, opensubtitles.OpenSubtitles):
         self.others_file = f"{self.outfile}.mka"
 
         # Could check the is_dolby_vision and is_hdr10plus properties here...
-        self.dolby_vision_file = hdr_utils.dovi_extract(
+        self.dolby_vision_file, self.hdr10plus_file = hdr_utils.extract_hdr(
             self.infile,
             self.outfile,
-        )
-        self.hdr10plus_file = hdr_utils.hdr10plus_extract(
-            self.infile,
-            self.outfile,
+            crop=self.crop,
         )
 
         if self.dolby_vision_file is None and self.hdr10plus_file is None:
@@ -681,7 +697,10 @@ class VideoConverter(ComRemove, MediaInfo, opensubtitles.OpenSubtitles):
                     err,
                 )
 
-    def _ffmpeg_command(self, video_file: str) -> list[str]:
+    def _ffmpeg_command(
+        self,
+        video_file: str,
+    ) -> list[str]:
         """
         A method to generate full ffmpeg command list
 
@@ -698,12 +717,16 @@ class VideoConverter(ComRemove, MediaInfo, opensubtitles.OpenSubtitles):
 
         cmd = self._ffmpeg_base()
 
-        # Attempt to detect cropping
-        crop_vals = cropdetect(
-            self.infile,
-            self.video_size,
-            threads=self.threads,
-        )
+        if self.crop:
+            # Attempt to detect cropping
+            crop_vals = cropdetect(
+                self.infile,
+                self.video_size,
+                threads=self.threads,
+            )
+        else:
+            crop_vals = None
+
         video_keys = self._video_keys()
         audio_keys = self._audio_keys()
         # Booleans for if all av options have been parsed

--- a/src/video_utils/watchdogs/makemkv.py
+++ b/src/video_utils/watchdogs/makemkv.py
@@ -211,6 +211,7 @@ def cli():
             transcode_log=get_transcode_log(parser.prog),
             comskip_log=get_comskip_log(parser.prog),
             recursive=args.recursive,
+            crop=args.crop,
         )
     except:
         log.exception('Something went wrong! Watchdog failed to start')


### PR DESCRIPTION
Main update is to handle Dolby Vision FEL data, where a second video stream is used for difference data in 12 bit streams. This caused pipeline to fail as was a check for only single video stream. This has been updated to enforce only single stream for 1080p or lower resolution and allow for up to two streams for video over 1080, with the assumption that second video stream is FEL data.

In the case of FEL data, then first video stream is re-encoded as before, with the second stream just copied directly in to output file in the mkv merge stage.

Have also added new extract_hdr() function that combines the extraction of dovi and hdr10plus into single command for speed up. As each of the previous commands had to run ffmpeg for extraction of video stream, we no just run one extraction and tree that output into both the dovi_tool and hdr10plus_tool so that both can work at same time. Is roughly twice as fast as only need single read of the source file now.

Adds --crop flag to the CLI with default to NOT crop data. As this is now an option, whereas previous versions enforced cropping, have added a crop keyword to the new extract_hdr and the dovi_extract functions.

Renames the hdr_ingect() function to hdr_inject().